### PR TITLE
Allow query to be empty

### DIFF
--- a/src/SearchRequestAdapter.js
+++ b/src/SearchRequestAdapter.js
@@ -156,7 +156,7 @@ export class SearchRequestAdapter {
 
     Object.assign(typesenseSearchParams, {
       collection: this._adaptIndexName(instantsearchRequest.indexName),
-      q: params.query === "" ? "*" : params.query,
+      q: (params.query === "" || params.query === undefined) ? "*" : params.query,
       facet_by: [params.facets].flat().join(","),
       filter_by: this._adaptFilters(params.facetFilters, params.numericFilters),
       sort_by: adaptedSortBy || this.additionalSearchParameters.sortBy,

--- a/src/SearchRequestAdapter.js
+++ b/src/SearchRequestAdapter.js
@@ -156,7 +156,7 @@ export class SearchRequestAdapter {
 
     Object.assign(typesenseSearchParams, {
       collection: this._adaptIndexName(instantsearchRequest.indexName),
-      q: (params.query === "" || params.query === undefined) ? "*" : params.query,
+      q: params.query === "" || params.query === undefined ? "*" : params.query,
       facet_by: [params.facets].flat().join(","),
       filter_by: this._adaptFilters(params.facetFilters, params.numericFilters),
       sort_by: adaptedSortBy || this.additionalSearchParameters.sortBy,


### PR DESCRIPTION
This small fix would allow "empty" queries to proceed without any exceptions from this adapter.

For example: If you do not add a search box instantsearch will not set a query and this adapter would fail.

Also it solves this issue #43 that I had. For some reason instantsearch triggers an empty request in my setup and then comes back with an error which results in absolute failure. Also resolves #44 

Would be great if we could merge this!

## Change Summary
<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
