### PR TITLE
adds equal operator in numeric adapter filter

### DIFF
--- a/src/SearchRequestAdapter.js
+++ b/src/SearchRequestAdapter.js
@@ -175,7 +175,7 @@ export class SearchRequestAdapter {
     // };
     const filtersHash = {};
     numericFilters.forEach((filter) => {
-      const [, field, operator, value] = filter.match(new RegExp("(.*)(<=|>=|>|<|:)(.*)"));
+      const [, field, operator, value] = filter.match(new RegExp("(.*?)(<=|>=|>|<|:|=)(.*)"));
       filtersHash[field] = filtersHash[field] || {};
       filtersHash[field][operator] = value;
     });
@@ -190,6 +190,8 @@ export class SearchRequestAdapter {
         adaptedFilters.push(`${field}:<=${filtersHash[field]["<="]}`);
       } else if (filtersHash[field][">="] != null) {
         adaptedFilters.push(`${field}:>=${filtersHash[field][">="]}`);
+      } else if (filtersHash[field]["="] != null) {
+        adaptedFilters.push(`${field}:=${filtersHash[field]["="]}`);
       } else {
         console.warn(
           `[Typesense-Instantsearch-Adapter] Unsupported operator found ${JSON.stringify(filtersHash[field])}`


### PR DESCRIPTION
## Change Summary
In reference to this Slack conversation: https://typesense-community.slack.com/archives/C01P749MET0/p1653080038634059?thread_ts=1653069002.224049&cid=C01P749MET0

This PR:

1. updates the RegEx for `numericFilters` in the search request adapter
2. modifies the conditional afterwards to map the `=` operator to typesense's `:=`

## PR Checklist
<!--- Put an `x` inside the box : -->
- [ x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
