### PR TITLE
doc(readme): added path parameter to server config

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ const typesenseInstantsearchAdapter = new TypesenseInstantSearchAdapter({
     nodes: [
       {
         host: "localhost",
-        path: '/', // Optional. Example: If you have your typesense mounted in localhost:8108/typesense, path should be equal to '/typesense'
+        path: '', // Optional. Example: If you have your typesense mounted in localhost:8108/typesense, path should be equal to '/typesense'
         port: "8108",
         protocol: "http",
       },
@@ -146,7 +146,7 @@ const typesenseInstantsearchAdapter = new TypesenseInstantSearchAdapter({
       {
         host: "localhost",
         port: "8108",
-        path: '/', // Optional. Example: If you have your typesense mounted in localhost:8108/typesense, path should be equal to '/typesense'
+        path: '', // Optional. Example: If you have your typesense mounted in localhost:8108/typesense, path should be equal to '/typesense'
         protocol: "http",
       },
     ],
@@ -198,7 +198,7 @@ const typesenseInstantsearchAdapter = new TypesenseInstantSearchAdapter({
     nodes: [
       {
         host: "localhost",
-        path: '/', // Optional. Example: If you have your typesense mounted in localhost:8108/typesense, path should be equal to '/typesense'
+        path: '', // Optional. Example: If you have your typesense mounted in localhost:8108/typesense, path should be equal to '/typesense'
         port: "8108",
         protocol: "http",
       },
@@ -239,7 +239,7 @@ const typesenseInstantsearchAdapter = new TypesenseInstantSearchAdapter({
     nodes: [
       {
         host: "localhost",
-        path: '/', // Optional. Example: If you have your typesense mounted in localhost:8108/typesense, path should be equal to '/typesense'
+        path: '', // Optional. Example: If you have your typesense mounted in localhost:8108/typesense, path should be equal to '/typesense'
         port: "8108",
         protocol: "http",
       },

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ const typesenseInstantsearchAdapter = new TypesenseInstantSearchAdapter({
     nodes: [
       {
         host: "localhost",
+        path: '/', // Optional. Example: If you have your typesense mounted in localhost:8108/typesense, path should be equal to '/typesense'
         port: "8108",
         protocol: "http",
       },
@@ -145,6 +146,7 @@ const typesenseInstantsearchAdapter = new TypesenseInstantSearchAdapter({
       {
         host: "localhost",
         port: "8108",
+        path: '/', // Optional. Example: If you have your typesense mounted in localhost:8108/typesense, path should be equal to '/typesense'
         protocol: "http",
       },
     ],
@@ -196,6 +198,7 @@ const typesenseInstantsearchAdapter = new TypesenseInstantSearchAdapter({
     nodes: [
       {
         host: "localhost",
+        path: '/', // Optional. Example: If you have your typesense mounted in localhost:8108/typesense, path should be equal to '/typesense'
         port: "8108",
         protocol: "http",
       },
@@ -236,6 +239,7 @@ const typesenseInstantsearchAdapter = new TypesenseInstantSearchAdapter({
     nodes: [
       {
         host: "localhost",
+        path: '/', // Optional. Example: If you have your typesense mounted in localhost:8108/typesense, path should be equal to '/typesense'
         port: "8108",
         protocol: "http",
       },
@@ -317,7 +321,7 @@ For Federated / Multi-Index Search, you'd need to use the `index` widget. To the
 const typesenseInstantsearchAdapter = new TypesenseInstantSearchAdapter({
   server: {
     apiKey: "abcd", // Be sure to use an API key that only allows search operations
-    nodes: [{ host: "localhost", port: "8108", protocol: "http" }],
+    nodes: [{ host: "localhost", path:'/', port: "8108", protocol: "http" }],
   },
   // Search parameters that are common to all collections/indices go here:
   additionalSearchParameters: {
@@ -351,6 +355,7 @@ const typesenseInstantsearchAdapter = new TypesenseInstantSearchAdapter({
       {
         host: "localhost",
         port: "8108",
+        path: "/",
         protocol: "http",
       },
     ],


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
Although the 'path' parameter is optional to configure the connection to the server, in case of having the typesense server in a subdomain (for example localhost:443/typesense) if the path is not specified, the default behavior of typesense-js is to concatenate the port at the end:

`localhost/typesense:443`

This is not documented anywhere else and can cause headaches when configuring the client. In my case I had to navigate to the typesense-js source code and find the existence of an optional 'path' parameter:
``` return "".concat(node.protocol, "://").concat(node.host, ":").concat(node.port).concat(node.path).concat(endpoint);
```

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
