### PR TITLE
allowing hidden fields with highlighted snippets to show up in hit highlight results

### DIFF
--- a/src/SearchResponseAdapter.js
+++ b/src/SearchResponseAdapter.js
@@ -166,9 +166,20 @@ export class SearchResponseAdapter {
   }
 
   _adaptHighlightInObjectValue(objectValue, highlightObjectValue, snippetOrValue) {
+    let fieldValueEntriesToHighlight = Object.entries(objectValue);
+    let fieldsToHighlightNotInDocument = Object.keys(highlightObjectValue).filter(
+      (field) => !Object.keys(objectValue).includes(field)
+    );
+    if (fieldsToHighlightNotInDocument) {
+      let hiddenEntries = fieldsToHighlightNotInDocument.map((field) => {
+        return [field, highlightObjectValue[field][snippetOrValue] || highlightObjectValue[field]["snippet"] || ""];
+      });
+      fieldValueEntriesToHighlight.push(...hiddenEntries);
+    }
+
     return Object.assign(
       {},
-      ...Object.entries(objectValue).map(([attribute, value]) => {
+      ...fieldValueEntriesToHighlight.map(([attribute, value]) => {
         let adaptedValue;
         if (value == null) {
           adaptedValue = this._adaptHighlightNullValue();

--- a/test/SearchResponseAdpater.test.js
+++ b/test/SearchResponseAdpater.test.js
@@ -270,6 +270,11 @@ describe("SearchResponseAdapter", () => {
             matchLevel: "none",
             matchedWords: [],
           },
+          hidden_field_to_highlight: {
+            value: "Secret <mark>Stark</mark> Industries",
+            matchLevel: "full",
+            matchedWords: ["Stark"],
+          },
         });
       });
     });

--- a/test/support/data/typesense-search-response-with-highlight-to-0.24.0-rcn32-and-above.json
+++ b/test/support/data/typesense-search-response-with-highlight-to-0.24.0-rcn32-and-above.json
@@ -32,26 +32,24 @@
               },
               {
                 "city": {
-                  "matched_tokens": [
-                    "Houston"
-                  ],
+                  "matched_tokens": ["Houston"],
                   "snippet": "<mark>Houston</mark>"
                 }
               }
             ],
             "company_name": {
-              "matched_tokens": [
-                "Stark"
-              ],
+              "matched_tokens": ["Stark"],
               "snippet": "<mark>Stark</mark> Industries"
+            },
+            "hidden_field_to_highlight": {
+              "matched_tokens": ["Stark"],
+              "snippet": "Secret <mark>Stark</mark> Industries"
             }
           },
           "highlights": [
             {
               "field": "company_name",
-              "matched_tokens": [
-                "Stark"
-              ],
+              "matched_tokens": ["Stark"],
               "snippet": "<mark>Stark</mark> Industries",
               "value": "<mark>Stark</mark> Industries"
             }


### PR DESCRIPTION
## Change Summary
I've added a code snippet showing one way to add highlight results to the search hits, when the field that is being highlighted is excluded from the document.

This is something we need, and I've added something to the test data to simulate for it. The response adapter tests work, but couldn't get the entire test suit to run (probably windows related).

I hope you guys can add something similar to the main repo, but I can use this for now.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
