### PR TITLE
ci: bump actions/upload-artifact version to v4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Run tests
         run: npm test -- --ci --color
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: screenshots


### PR DESCRIPTION
## Change Summary
Since actions/upload-artifact@v3 is getting deprecated, new workflow runs will be failing after [Jan 30](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/). This just bumps the version to the latest supported one.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
