### PR TITLE
 fix(types): add generic type support for document schema

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -123,11 +123,11 @@ type AdapterOptionsWithQueryByInAdditionalSearchParameters<T extends DocumentSch
 type AdapterOptionWithQueryByInCollectionSpecificSearchParameters<T extends DocumentSchema> =
   AdditionalSearchParametersOptionalQueryBy<T> & CollectionSpecificSearchParametersWithQueryBy;
 
-type TypesenseInstantsearchAdapterOptions<T extends DocumentSchema> =
+type TypesenseInstantsearchAdapterOptions<T extends DocumentSchema = DocumentSchema> =
   | AdapterOptionWithQueryByInCollectionSpecificSearchParameters<T>
   | AdapterOptionsWithQueryByInAdditionalSearchParameters<T>;
 
-export default class TypesenseInstantsearchAdapter<T extends DocumentSchema> {
+export default class TypesenseInstantsearchAdapter<T extends DocumentSchema = DocumentSchema> {
   readonly searchClient: SearchClient;
   readonly typesenseClient: TypesenseSearchClient;
   constructor(options: TypesenseInstantsearchAdapterOptions<T>);

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,10 +3,11 @@ import type { SearchClient as AlgoliaSearchClient, CompositionClient } from "ins
 type SearchClient = CompositionClient | AlgoliaSearchClient;
 
 import type { ConfigurationOptions } from "typesense/lib/Typesense/Configuration";
-import type { SearchParamsWithPreset } from "typesense/lib/Typesense/Documents";
+import type { DocumentSchema, SearchParamsWithPreset } from "typesense/lib/Typesense/Documents";
 import { default as TypesenseSearchClient } from "typesense/lib/Typesense/SearchClient";
 
-interface BaseSearchParameters extends Partial<Omit<SearchParamsWithPreset, "q" | "filter_by">> {
+interface BaseSearchParameters<T extends DocumentSchema>
+  extends Partial<Omit<SearchParamsWithPreset<T>, "q" | "filter_by">> {
   /**
    * @deprecated Please use the snake_cased version of this parameter
    */
@@ -99,16 +100,14 @@ interface BaseAdapterOptions {
   collectionSpecificSortByOptions?: object;
 }
 
-interface CollectionSearchParameters {
-  [key: string]: BaseSearchParameters;
+type CollectionSearchParameters = Record<string, BaseSearchParameters<DocumentSchema>>;
+
+interface AdditionalSearchParametersWithQueryBy<T extends DocumentSchema> extends BaseAdapterOptions {
+  additionalSearchParameters: BaseSearchParameters<T>;
 }
 
-interface AdditionalSearchParametersWithQueryBy extends BaseAdapterOptions {
-  additionalSearchParameters: BaseSearchParameters;
-}
-
-interface AdditionalSearchParametersOptionalQueryBy extends BaseAdapterOptions {
-  additionalSearchParameters?: BaseSearchParameters;
+interface AdditionalSearchParametersOptionalQueryBy<T extends DocumentSchema> extends BaseAdapterOptions {
+  additionalSearchParameters?: BaseSearchParameters<T>;
 }
 
 interface CollectionSpecificSearchParametersWithQueryBy extends BaseAdapterOptions {
@@ -119,19 +118,19 @@ interface CollectionSpecificSearchParametersOptionalQueryBy extends BaseAdapterO
   collectionSpecificSearchParameters?: CollectionSearchParameters;
 }
 
-type AdapterOptionsWithQueryByInAdditionalSearchParameters = AdditionalSearchParametersWithQueryBy &
-  CollectionSpecificSearchParametersOptionalQueryBy;
-type AdapterOptionWithQueryByInCollectionSpecificSearchParameters = AdditionalSearchParametersOptionalQueryBy &
-  CollectionSpecificSearchParametersWithQueryBy;
+type AdapterOptionsWithQueryByInAdditionalSearchParameters<T extends DocumentSchema> =
+  AdditionalSearchParametersWithQueryBy<T> & CollectionSpecificSearchParametersOptionalQueryBy;
+type AdapterOptionWithQueryByInCollectionSpecificSearchParameters<T extends DocumentSchema> =
+  AdditionalSearchParametersOptionalQueryBy<T> & CollectionSpecificSearchParametersWithQueryBy;
 
-type TypesenseInstantsearchAdapterOptions =
-  | AdapterOptionWithQueryByInCollectionSpecificSearchParameters
-  | AdapterOptionsWithQueryByInAdditionalSearchParameters;
+type TypesenseInstantsearchAdapterOptions<T extends DocumentSchema> =
+  | AdapterOptionWithQueryByInCollectionSpecificSearchParameters<T>
+  | AdapterOptionsWithQueryByInAdditionalSearchParameters<T>;
 
-export default class TypesenseInstantsearchAdapter {
+export default class TypesenseInstantsearchAdapter<T extends DocumentSchema> {
   readonly searchClient: SearchClient;
   readonly typesenseClient: TypesenseSearchClient;
-  constructor(options: TypesenseInstantsearchAdapterOptions);
+  constructor(options: TypesenseInstantsearchAdapterOptions<T>);
   clearCache(): SearchClient;
-  updateConfiguration(options: TypesenseInstantsearchAdapterOptions): boolean;
+  updateConfiguration(options: TypesenseInstantsearchAdapterOptions<T>): boolean;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "typesense": "^2.1.0-1"
+        "typesense": "^2.1.0-5"
       },
       "devDependencies": {
         "@babel/cli": "^7.24.1",
@@ -12341,9 +12341,9 @@
       }
     },
     "node_modules/typesense": {
-      "version": "2.1.0-2",
-      "resolved": "https://registry.npmjs.org/typesense/-/typesense-2.1.0-2.tgz",
-      "integrity": "sha512-P6ExbB30OUmSlizOE0+EnrHhnj9AVy95Ps8K4ybC0EWAxCy4Qrrn9Ps9ISkzv3OnlbYrSKK9NR3iDs4qU88KYg==",
+      "version": "2.1.0-5",
+      "resolved": "https://registry.npmjs.org/typesense/-/typesense-2.1.0-5.tgz",
+      "integrity": "sha512-dNXS3iEMRsVVgjDN9GjrqXvgifoigUbnQM+dV4DuTZkvUg97lHgP0q2XmzfZ/VbRBRIBaIwCtVNxswXovFjw+Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.8.4",
@@ -21894,9 +21894,9 @@
       "dev": true
     },
     "typesense": {
-      "version": "2.1.0-2",
-      "resolved": "https://registry.npmjs.org/typesense/-/typesense-2.1.0-2.tgz",
-      "integrity": "sha512-P6ExbB30OUmSlizOE0+EnrHhnj9AVy95Ps8K4ybC0EWAxCy4Qrrn9Ps9ISkzv3OnlbYrSKK9NR3iDs4qU88KYg==",
+      "version": "2.1.0-5",
+      "resolved": "https://registry.npmjs.org/typesense/-/typesense-2.1.0-5.tgz",
+      "integrity": "sha512-dNXS3iEMRsVVgjDN9GjrqXvgifoigUbnQM+dV4DuTZkvUg97lHgP0q2XmzfZ/VbRBRIBaIwCtVNxswXovFjw+Q==",
       "requires": {
         "axios": "^1.8.4",
         "loglevel": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "webpack-cli": "^5.1.4"
   },
   "dependencies": {
-    "typesense": "^2.1.0-1"
+    "typesense": "^2.1.0-5"
   },
   "peerDependencies": {
     "@babel/runtime": "^7.24.1"


### PR DESCRIPTION
### TLDR
Enhanced TypeScript support with generic types for better type safety and schema validation based on latest `typesense-js` version.

## Change Summary

#### Type System Improvements:
1. **In `index.d.ts`**:
   - **`TypesenseInstantsearchAdapter` class**: Added generic type parameter `<T extends DocumentSchema>` for type-safe document schema handling
   - **`BaseSearchParameters` interface**: Extended with generic `<T extends DocumentSchema>` parameter and updated to use `SearchParamsWithPreset<T>`
   - **`CollectionSearchParameters` type**: Replaced index signature with `Record<string, BaseSearchParameters<DocumentSchema>>` for better type safety

#### Interface Updates:
1. **In `index.d.ts`**:
   - **`AdditionalSearchParametersWithQueryBy`**: Added generic type parameter `<T extends DocumentSchema>`
   - **`AdditionalSearchParametersOptionalQueryBy`**: Added generic type parameter `<T extends DocumentSchema>`
   - **`TypesenseInstantsearchAdapterOptions`**: Updated to use generic types in union type definitions
   - **Constructor and methods**: Updated `constructor()` and `updateConfiguration()` to accept generic type parameters

#### Code Quality:
1. **In `index.d.ts`**:
   - Fixed duplicate import by adding `DocumentSchema` to existing `SearchParamsWithPreset` import
   - Improved type definitions for better LSP and compile-time checking

#### Dependencies:
1. **In `package.json` and `package-lock.json`**:
   - **Typesense version**: Bumped from `^2.1.0-1` to `^2.1.0-5` for latest features and bug fixes


### Context
This change improves the TypeScript developer experience by providing stronger type safety when working with Typesense document schemas. The generic type parameter ensures that search parameters are properly typed according to the specific document schema being used, reducing runtime errors and improving code maintainability.