### PR TITLE
Algolia expects `facetHits` to be an array

### DIFF
--- a/src/FacetSearchResponseAdapter.js
+++ b/src/FacetSearchResponseAdapter.js
@@ -9,7 +9,7 @@ export class FacetSearchResponseAdapter {
   }
 
   _adaptFacetHits(typesenseFacetCounts) {
-    let adaptedResult = {};
+    let adaptedResult = [];
     const facet = typesenseFacetCounts.find((facet) => facet.field_name === this.instantsearchRequest.params.facetName);
 
     if (typeof facet !== 'undefined') {


### PR DESCRIPTION
Even when there are no results, `facetHits` should be an (empty) array.

## Change Summary
I made a mistake in #245.  After reviewing Algolia's code and this adapter's code, this should be correct.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
