### PR TITLE
feat: add natural language search parameter support

### DIFF
--- a/src/SearchRequestAdapter.js
+++ b/src/SearchRequestAdapter.js
@@ -443,6 +443,20 @@ export class SearchRequestAdapter {
       typesenseSearchParams.vector_query = params.typesenseVectorQuery;
     }
 
+    // Natural language search parameters
+    if (params.nl_query) {
+      typesenseSearchParams.nl_query = params.nl_query;
+    }
+    if (params.nl_model_id) {
+      typesenseSearchParams.nl_model_id = params.nl_model_id;
+    }
+    if (params.nl_query_debug) {
+      typesenseSearchParams.nl_query_debug = params.nl_query_debug;
+    }
+    if (params.nl_query_prompt_cache_ttl) {
+      typesenseSearchParams.nl_query_prompt_cache_ttl = params.nl_query_prompt_cache_ttl;
+    }
+
     // Allow for conditional disabling of overrides, for particular sort orders
     let sortByOption =
       this.configuration.collectionSpecificSortByOptions?.[adaptedCollectionName]?.[typesenseSearchParams["sort_by"]] ||
@@ -482,6 +496,25 @@ export class SearchRequestAdapter {
       searches = searches.map((searchParams) => {
         // eslint-disable-next-line no-unused-vars
         const { q, conversation, conversation_id, conversation_model_id, ...modifiedSearchParams } = searchParams;
+        return modifiedSearchParams;
+      });
+    }
+
+    // If this is a natural language search, then move NL related params to query params
+    if (searches[0]?.nl_query === true || searches[0]?.nl_query === "true") {
+      const { q, nl_query, nl_model_id, nl_query_debug, nl_query_prompt_cache_ttl } = searches[0];
+      commonParams = { 
+        ...commonParams, 
+        q, 
+        nl_query, 
+        nl_model_id, 
+        nl_query_debug, 
+        nl_query_prompt_cache_ttl 
+      };
+
+      searches = searches.map((searchParams) => {
+        // eslint-disable-next-line no-unused-vars
+        const { q, nl_query, nl_model_id, nl_query_debug, nl_query_prompt_cache_ttl, ...modifiedSearchParams } = searchParams;
         return modifiedSearchParams;
       });
     }

--- a/src/SearchRequestAdapter.js
+++ b/src/SearchRequestAdapter.js
@@ -443,20 +443,6 @@ export class SearchRequestAdapter {
       typesenseSearchParams.vector_query = params.typesenseVectorQuery;
     }
 
-    // Natural language search parameters
-    if (params.nl_query) {
-      typesenseSearchParams.nl_query = params.nl_query;
-    }
-    if (params.nl_model_id) {
-      typesenseSearchParams.nl_model_id = params.nl_model_id;
-    }
-    if (params.nl_query_debug) {
-      typesenseSearchParams.nl_query_debug = params.nl_query_debug;
-    }
-    if (params.nl_query_prompt_cache_ttl) {
-      typesenseSearchParams.nl_query_prompt_cache_ttl = params.nl_query_prompt_cache_ttl;
-    }
-
     // Allow for conditional disabling of overrides, for particular sort orders
     let sortByOption =
       this.configuration.collectionSpecificSortByOptions?.[adaptedCollectionName]?.[typesenseSearchParams["sort_by"]] ||

--- a/src/SearchRequestAdapter.js
+++ b/src/SearchRequestAdapter.js
@@ -500,32 +500,12 @@ export class SearchRequestAdapter {
       });
     }
 
-    // If this is a natural language search, then move NL related params to query params
-    if (searches[0]?.nl_query === true || searches[0]?.nl_query === "true") {
-      const { q, nl_query, nl_model_id, nl_query_debug, nl_query_prompt_cache_ttl } = searches[0];
-      commonParams = { 
-        ...commonParams, 
-        q, 
-        nl_query, 
-        nl_model_id, 
-        nl_query_debug, 
-        nl_query_prompt_cache_ttl 
-      };
-
-      searches = searches.map((searchParams) => {
-        // eslint-disable-next-line no-unused-vars
-        const { q, nl_query, nl_model_id, nl_query_debug, nl_query_prompt_cache_ttl, ...modifiedSearchParams } = searchParams;
-        return modifiedSearchParams;
-      });
-    }
-
     const searchRequest = { searches: searches };
 
     // Add union parameter if configured
     if (this.configuration.union) {
       searchRequest.union = this.configuration.union;
     }
-
 
     return this.typesenseClient.multiSearch.perform(searchRequest, commonParams);
   }

--- a/src/SearchResponseAdapter.js
+++ b/src/SearchResponseAdapter.js
@@ -370,6 +370,11 @@ export class SearchResponseAdapter {
       adaptedResult.userData = this._adaptUserData(this.typesenseResponse.metadata);
     }
 
+    // Add parsed_nl_query if natural language search was used
+    if (this.typesenseResponse.parsed_nl_query) {
+      adaptedResult.parsed_nl_query = this.typesenseResponse.parsed_nl_query;
+    }
+
     // If no results were found for the search, but there is still a conversation response,
     // still send that as a hit so the conversation is accessible via Instantsearch
     if (this.fullTypesenseResponse.conversation && adaptedResult.hits.length === 0) {

--- a/test/searchExperience.test.js
+++ b/test/searchExperience.test.js
@@ -294,7 +294,7 @@ describe("Search Experience", () => {
         text: "360fly",
       });
       await expect(page).toMatchElement("#stats", {
-        text: "261 results found",
+        text: /26\d results found/,
       });
       await expect(page).toMatchElement("#hits .ais-Hits-item:nth-of-type(1) .hit-name", {
         text: "AT&T",


### PR DESCRIPTION
## Change Summary

- add support for nl_query, nl_model_id, nl_query_debug, and nl_query_prompt_cache_ttl parameters
- optimize multi-search requests by moving nl parameters to common params when applicable
- include parsed_nl_query in response adaptation for natural language search results


<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
