### PR TITLE
fix: add missing page parameter for union search pagination

### DIFF
--- a/src/SearchRequestAdapter.js
+++ b/src/SearchRequestAdapter.js
@@ -491,6 +491,7 @@ export class SearchRequestAdapter {
     // Add union parameter if configured
     if (this.configuration.union) {
       searchRequest.union = this.configuration.union;
+      commonParams.page = searches[0].page;
     }
 
     return this.typesenseClient.multiSearch.perform(searchRequest, commonParams);

--- a/test/SearchRequestAdpater.test.js
+++ b/test/SearchRequestAdpater.test.js
@@ -332,7 +332,9 @@ describe("SearchRequestAdapter", () => {
               },
             ],
           },
-          {},
+          {
+            page: 1,
+          },
         );
       });
 
@@ -466,6 +468,7 @@ describe("SearchRequestAdapter", () => {
             conversation: true,
             conversation_id: "conv_123",
             conversation_model_id: "model_456",
+            page: 1,
           },
         );
       });
@@ -507,7 +510,9 @@ describe("SearchRequestAdapter", () => {
               },
             ],
           },
-          {},
+          {
+            page: 1,
+          },
         );
       });
     });

--- a/test/unionSearch.test.js
+++ b/test/unionSearch.test.js
@@ -58,4 +58,37 @@ describe("Union Search", () => {
       });
     });
   });
+
+  describe("pagination with union search", () => {
+    beforeEach(async () => {
+      return expect(page).toFill("#searchbox input[type=search]", "phone");
+    });
+
+    it("renders pagination controls for merged results from multiple indices", async () => {
+      await page.waitForSelector("#pagination a.ais-Pagination-link");
+
+      const paginationLinks = await page.$$("#pagination a.ais-Pagination-link");
+      expect(paginationLinks.length).toBeGreaterThan(0);
+
+      await expect(page).toMatchElement("#hits .ais-Hits-item:nth-of-type(1)");
+    });
+
+    it("shows different merged results when navigating to the second page", async () => {
+      await page.waitForSelector("#pagination a.ais-Pagination-link");
+
+      const firstPageFirstResult = await page.$eval("#hits .ais-Hits-item:nth-of-type(1)", (el) => el.textContent);
+
+      await expect(page).toClick("#pagination a", { text: "2" });
+
+      await page.waitForSelector("#hits .ais-Hits-item:nth-of-type(1)");
+
+      const secondPageFirstResult = await page.$eval("#hits .ais-Hits-item:nth-of-type(1)", (el) => el.textContent);
+
+      expect(firstPageFirstResult).not.toBe(secondPageFirstResult);
+
+      await expect(page).toMatchElement("#hits");
+      await expect(page).not.toMatchElement("#product-hits", { timeout: 1000 });
+      await expect(page).not.toMatchElement("#brand-hits", { timeout: 1000 });
+    });
+  });
 });


### PR DESCRIPTION
## Change Summary
Fix #253 

- set commonParams.page from first search request when union is configured
- add pagination tests for union search with multi-index result merging
- ensure different results are shown when navigating between pages


<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
