### PR TITLE
ci: let puppeteer handle chrome installation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,33 +12,6 @@ jobs:
           node-version: 22
           cache: npm
 
-      - name: Install Puppeteer dependencies
-        run: |
-          sudo apt-get update
-          sudo apt install -y --no-install-recommends \
-            libnss3 \
-            libdbus-1-3 \
-            libatk1.0-0 \
-            libasound2t64 \
-            libxrandr2 \
-            libxkbcommon-dev \
-            libxfixes3 \
-            libxcomposite1 \
-            libxdamage1 \
-            libgbm-dev \
-            libatk-bridge2.0-0 \
-            binutils \
-            libglib2.0-0 \
-            libgdk-pixbuf2.0-0 \
-            libgtk-3-0 \
-            libnss3-dev \
-            libxss-dev \
-            xvfb \
-            fonts-liberation \
-            libu2f-udev \
-            xdg-utils \
-            chromium-browser
-
       - name: Install dependencies
         run: npm ci
 

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -6,7 +6,7 @@ module.exports = {
     headless: isDebugMode ? false : true,
     slowMo: 10,
     defaultViewport: null,
-    executablePath: process.env.CHROME_PATH,
+    ...(process.env.CHROME_PATH ? { executablePath: process.env.CHROME_PATH } : {}),
     args: ["--no-sandbox", "--disable-setuid-sandbox"],
   },
   server: [


### PR DESCRIPTION
## Change Summary
Let puppeteer handle Chrome installation, to avoid hanging snap package installs, it [currently fails because of it](https://github.com/typesense/typesense-instantsearch-adapter/actions/runs/23602504924)

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
